### PR TITLE
[LP#2046456] Focal's hostnamectl cannot determine the vendor of a cloud

### DIFF
--- a/.github/workflows/naming-lint-unit.yaml
+++ b/.github/workflows/naming-lint-unit.yaml
@@ -4,21 +4,11 @@ on: [pull_request]
 jobs:
   call-inclusive-naming-check:
     name: Inclusive Naming
-    uses: canonical-web-and-design/Inclusive-naming/.github/workflows/woke.yaml@main
+    uses: canonical/inclusive-naming/.github/workflows/woke.yaml@main
     with:
       fail-on-error: "true"
-  lint:
-    name: Lint
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v3
-      - name: Setup Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.10"
-      - name: Install Dependencies
-        run: |
-          pip install tox
-      - name: Lint
-        run: tox -vve lint
+  call-lint-and-unit:
+    name: Inclusive Naming
+    uses: charmed-kubernetes/workflows/.github/workflows/lint-unit.yaml@main
+    with:
+      python: "['3.8', '3.9', '3.10', '3.11', '3.12']"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+**/__pycache__
+.coverage

--- a/charms/interface_external_cloud_provider.py
+++ b/charms/interface_external_cloud_provider.py
@@ -15,7 +15,7 @@ CLOUD_PROVIDERS = [
     {"name": "openstack", "vendor": "OpenStack"},
     {"name": "azure", "vendor": "Microsoft"},
     {"name": "gce", "vendor": "Google"},
-    {"name": "vsphere", "vendor": "VMware"},
+    {"name": "vsphere", "vendor": "VMWare"},
 ]
 
 OPENSTACK_METADATA = "http://169.254.169.254/openstack/2018-08-27/meta_data.json"
@@ -57,28 +57,27 @@ class ExternalCloudProvider:
         return False
 
     @cached_property
-    def hostnamectl(self):
+    def _vendor(self):
         """
         Since the external-cloud-provider is joined, but no name is
         found over the relation, we can guess the cloud name using
-        hostnamectl.
+        dmidecode.
         """
         try:
-            hostnamectl = check_output(["hostnamectl", "--json=short"])
+            vendor = check_output(["dmidecode", "-s", "system-manufacturer"])
         except CalledProcessError as e:
-            log.warning("hostnamectl failure", e)
+            log.warning("dmidecode failure: %s", e)
             return None
-
-        return json.loads(hostnamectl)
+        return vendor
 
     @cached_property
     def name(self) -> Optional[str]:
         """Name of the cloud-provider."""
-        vendor = self.hostnamectl.get("HardwareVendor")
+        vendor = self._vendor
         if vendor:
             log.info(f"Determined this cloud provider is {vendor}")
         else:
-            log.warning(f"Cannot determine cloud provider from {self.hostnamectl}")
+            log.warning(f"Cannot determine cloud provider from {vendor}")
             return None
 
         for cloud in CLOUD_PROVIDERS:

--- a/charms/interface_external_cloud_provider.py
+++ b/charms/interface_external_cloud_provider.py
@@ -68,7 +68,7 @@ class ExternalCloudProvider:
         except CalledProcessError as e:
             log.warning("dmidecode failure: %s", e)
             return None
-        return vendor
+        return vendor.decode()
 
     @cached_property
     def name(self) -> Optional[str]:

--- a/tests/test_interface_external_cloud.py
+++ b/tests/test_interface_external_cloud.py
@@ -1,0 +1,26 @@
+import charms.interface_external_cloud_provider as iecp
+from unittest import mock
+from pathlib import Path
+import pytest
+
+
+@pytest.mark.parametrize("vendor, cloud_name", [
+    ("Amazon EC2", "aws"),
+    ("Google", "gce"),
+    ("Microsoft Corporation", "azure"),
+    ("VMWare, Inc.", "vsphere"),
+    ("OpenStack Foundation", "openstack"),
+    ("Dell Inc.", None),
+])
+def test_vendor(vendor, cloud_name):
+    charm = mock.MagicMock()
+    with mock.patch("charms.interface_external_cloud_provider.check_output") as mock_subprocess:
+        mock_subprocess.return_value = vendor
+        ecp = iecp.ExternalCloudProvider(charm, "external-cloud-provider")
+        assert ecp.name == cloud_name
+
+def test_charm_attr():
+    charm = mock.MagicMock()
+    ecp = iecp.ExternalCloudProvider(charm, "external-cloud-provider")
+    assert ecp.unit == charm.unit
+

--- a/tests/test_interface_external_cloud.py
+++ b/tests/test_interface_external_cloud.py
@@ -1,26 +1,32 @@
-import charms.interface_external_cloud_provider as iecp
 from unittest import mock
-from pathlib import Path
+
 import pytest
 
+import charms.interface_external_cloud_provider as iecp
 
-@pytest.mark.parametrize("vendor, cloud_name", [
-    ("Amazon EC2", "aws"),
-    ("Google", "gce"),
-    ("Microsoft Corporation", "azure"),
-    ("VMWare, Inc.", "vsphere"),
-    ("OpenStack Foundation", "openstack"),
-    ("Dell Inc.", None),
-])
+
+@pytest.mark.parametrize(
+    "vendor, cloud_name",
+    [
+        ("Amazon EC2", "aws"),
+        ("Google", "gce"),
+        ("Microsoft Corporation", "azure"),
+        ("VMWare, Inc.", "vsphere"),
+        ("OpenStack Foundation", "openstack"),
+        ("Dell Inc.", None),
+    ],
+)
 def test_vendor(vendor, cloud_name):
     charm = mock.MagicMock()
-    with mock.patch("charms.interface_external_cloud_provider.check_output") as mock_subprocess:
+    with mock.patch(
+        "charms.interface_external_cloud_provider.check_output"
+    ) as mock_subprocess:
         mock_subprocess.return_value = vendor
         ecp = iecp.ExternalCloudProvider(charm, "external-cloud-provider")
         assert ecp.name == cloud_name
+
 
 def test_charm_attr():
     charm = mock.MagicMock()
     ecp = iecp.ExternalCloudProvider(charm, "external-cloud-provider")
     assert ecp.unit == charm.unit
-

--- a/tests/test_interface_external_cloud.py
+++ b/tests/test_interface_external_cloud.py
@@ -8,12 +8,12 @@ import charms.interface_external_cloud_provider as iecp
 @pytest.mark.parametrize(
     "vendor, cloud_name",
     [
-        ("Amazon EC2", "aws"),
-        ("Google", "gce"),
-        ("Microsoft Corporation", "azure"),
-        ("VMWare, Inc.", "vsphere"),
-        ("OpenStack Foundation", "openstack"),
-        ("Dell Inc.", None),
+        (b"Amazon EC2", "aws"),
+        (b"Google", "gce"),
+        (b"Microsoft Corporation", "azure"),
+        (b"VMWare, Inc.", "vsphere"),
+        (b"OpenStack Foundation", "openstack"),
+        (b"Dell Inc.", None),
     ],
 )
 def test_vendor(vendor, cloud_name):

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,8 @@ min_version = 4.0.0
 
 [vars]
 src_path = {tox_root}/charms
-all_path = {[vars]src_path}
+test_path = {tox_root}/tests
+all_path = {[vars]src_path} {[vars]test_path}
 
 [testenv]
 set_env =
@@ -37,3 +38,14 @@ commands =
     codespell {tox_root}
     ruff {[vars]all_path}
     black --check --diff {[vars]all_path}
+
+[testenv:unit]
+description = Run unit tests
+deps =
+    coverage[toml]
+    pytest
+    -e .
+commands =
+    coverage run --source={[vars]src_path} \
+        -m pytest --ignore={[vars]tst_path}integration -v --tb native -s {posargs}
+    coverage report


### PR DESCRIPTION
[LP#2046456](https://bugs.launchpad.net/charm-kubernetes-master/+bug/2046456)

Because focal's implementation of hostnamectl doesn't decode the dmi information, just use `dmidecode` to determine the vendor of the machine