### PR TITLE
Replace running dmidecode with reading from a file

### DIFF
--- a/.github/workflows/naming-lint-unit.yaml
+++ b/.github/workflows/naming-lint-unit.yaml
@@ -11,4 +11,4 @@ jobs:
     name: Inclusive Naming
     uses: charmed-kubernetes/workflows/.github/workflows/lint-unit.yaml@main
     with:
-      python: "['3.8', '3.9', '3.10', '3.11', '3.12']"
+      with-uv: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 **/__pycache__
 .coverage
+**/*.egg-info

--- a/charms/interface_external_cloud_provider.py
+++ b/charms/interface_external_cloud_provider.py
@@ -2,7 +2,6 @@ import json
 import logging
 from functools import cached_property
 from pathlib import Path
-from subprocess import CalledProcessError, check_output
 from typing import List, Optional
 from urllib.request import Request, urlopen
 
@@ -63,12 +62,12 @@ class ExternalCloudProvider:
         found over the relation, we can guess the cloud name using
         dmidecode.
         """
+        VENDOR_PATH = Path("/sys/devices/virtual/dmi/id/sys_vendor")
         try:
-            vendor = check_output(["dmidecode", "-s", "system-manufacturer"])
-        except CalledProcessError as e:
-            log.warning("dmidecode failure: %s", e)
+            return VENDOR_PATH.read_text()
+        except FileNotFoundError:
+            log.exception("Failed to find vendor: %s")
             return None
-        return vendor.decode()
 
     @cached_property
     def name(self) -> Optional[str]:

--- a/tests/test_interface_external_cloud.py
+++ b/tests/test_interface_external_cloud.py
@@ -8,19 +8,17 @@ import charms.interface_external_cloud_provider as iecp
 @pytest.mark.parametrize(
     "vendor, cloud_name",
     [
-        (b"Amazon EC2", "aws"),
-        (b"Google", "gce"),
-        (b"Microsoft Corporation", "azure"),
-        (b"VMware, Inc.", "vsphere"),
-        (b"OpenStack Foundation", "openstack"),
-        (b"Dell Inc.", None),
+        ("Amazon EC2", "aws"),
+        ("Google", "gce"),
+        ("Microsoft Corporation", "azure"),
+        ("VMware, Inc.", "vsphere"),
+        ("OpenStack Foundation", "openstack"),
+        ("Dell Inc.", None),
     ],
 )
 def test_vendor(vendor, cloud_name):
     charm = mock.MagicMock()
-    with mock.patch(
-        "charms.interface_external_cloud_provider.check_output"
-    ) as mock_subprocess:
+    with mock.patch("pathlib.Path.read_text", autospec=True) as mock_subprocess:
         mock_subprocess.return_value = vendor
         ecp = iecp.ExternalCloudProvider(charm, "external-cloud-provider")
         assert ecp.name == cloud_name

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ deps =
 commands =
     black {[vars]all_path}
     isort {[vars]all_path}
-    ruff --fix {[vars]all_path}
+    ruff check --fix {[vars]all_path}
 
 [testenv:lint]
 description = Check code against coding style standards
@@ -36,7 +36,7 @@ deps =
     codespell
 commands =
     codespell {tox_root}
-    ruff {[vars]all_path}
+    ruff check {[vars]all_path}
     black --check --diff {[vars]all_path}
 
 [testenv:unit]


### PR DESCRIPTION
### Overview

Reading the system-manufacturer with `dmidecode` requires root access and the app being installed.  Neither of these are necessary. 


### Details
* read from the `/sys/device` where the system manufacturer exists
* update the tests